### PR TITLE
Remove cython pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
     - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
     - CONTAINER="pre-release";
     - BUILD_COMMIT=$BUILD_COMMIT;
-    - BUILD_DEPENDS="$NP_BUILD_DEP cython==0.26.0"
+    - BUILD_DEPENDS="$NP_BUILD_DEP cython"
     - TEST_DEPENDS="$NP_TEST_DEP pytest moto"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh


### PR DESCRIPTION
The current pinning was too old to build pandas/master. Instead of
pinning it explicitly, I removed the pinning altogether to be in line
with pandas-wheels/master.