### PR TITLE
add mac wheels built for 10.9 / 64b only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,15 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_VERSION=3.6
         - MB_PYTHON_OSX_VER=10.9
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_VERSION=3.7
         - MB_PYTHON_OSX_VER=10.9
+        - NP_BUILD_DEP="numpy==1.14.5"
+        - NP_TEST_DEP="numpy==1.14.5"
 
 before_install:
     # See:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - MACOSX_DEPLOYMENT_TARGET=10.6 # since pandas PR24274, mac builds default to 10.9
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - MACOSX_DEPLOYMENT_TARGET=10.6 # since pandas PR24274, mac builds default to 10.9
-
-
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,16 @@ matrix:
         - MACOSX_DEPLOYMENT_TARGET=10.6 # since pandas PR24274, mac builds default to 10.9
 
 
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_OSX_VER=10.9
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_OSX_VER=10.9
 
 before_install:
     # See:

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,12 @@
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
     # Runs in the root directory of this repository.
-    :
+    if [ -n "$IS_OSX" ]; then
+        # Override pandas minimum MACOSX_DEPLOYEMENT_TARGET=10.9 so we can
+        # build for older Pythons
+        # See https://github.com/pandas-dev/pandas/pull/24274
+        export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(get_macpython_osx_ver)}
+    fi
 }
 
 function build_wheel {


### PR DESCRIPTION
resolves #42

Since https://github.com/matthew-brett/multibuild/pull/224, setting `MB_PYTHON_OSX_VER=10.9` in `.travis.yml` for `osx` targets will build for macOS 10.9+. These builds are 64bit only, and are available for Python versions 3.6.5+ / 2.7.15+ [see python.org](https://www.python.org/downloads/mac-osx/). 

The 64/32 bit builds for macOS 10.6+ are supported as before, by setting `MB_PYTHON_OSX_VER=10.6` or just omitting it.

The new 10.9 64 bit wheels have a few advantages over 10.6 dual arch wheels:
- extensions using the c++ api link to libc++ rather than libstdc++, which may not always be available on macOS 10.14 and above (i.e. risk that 10.6 wheels may not run on newer systems). See https://github.com/pandas-dev/pandas/issues/23424
- faster to build, around 30min vs 48min
- smaller filesize, typically 10Mb vs 16Mb
- shorter filename, e.g. `pandas-0.24.0-cp37-cp37m-macosx_10_9_x86_64.macosx_10_10_x86_64.whl` vs `pandas-0.24.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl`
