### PR TITLE
add mac wheels for 10.9 / 64b only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
       - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
+      - MB_PYTHON_OSX_VER=10.9
       - NP_BUILD_DEP="numpy==1.13.3"
       - NP_TEST_DEP="numpy==1.13.3"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -45,16 +46,15 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_OSX_VER=10.6 # no python.org 10.9 builds for 3.5
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
-        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP="numpy==1.14.5"
         - NP_TEST_DEP="numpy==1.14.5"
 

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,15 @@
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
     # Runs in the root directory of this repository.
-    :
+    if [ -n "$IS_OSX" ]; then
+        # Override pandas' default minimum MACOSX_DEPLOYEMENT_TARGET=10.9,
+        # so we can build for older Pythons if we really want to.
+        # See https://github.com/pandas-dev/pandas/pull/24274
+        local _plat=$(get_distutils_platform)
+        if [[ -z $MACOSX_DEPLOYMENT_TARGET && "$_plat" =~ macosx-(10\.[0-9]+)-.* ]]; then
+            export MACOSX_DEPLOYMENT_TARGET=${BASH_REMATCH[1]}
+        fi
+    fi
 }
 
 function build_wheel {


### PR DESCRIPTION
followup to https://github.com/MacPython/pandas-wheels/pull/46, which was partly reverted after merging.

resolves https://github.com/MacPython/pandas-wheels/issues/42 for the daily branch.

additional changes compared to https://github.com/MacPython/pandas-wheels/pull/46:
- `config.sh` is back compatible with older versions of the `multibuild` submodule
- 10.9 builds are the default, it makes `.travis.yml` a little cleaner to read