### PR TITLE
Debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code $REPO_DIR $BUILD_COMMIT
+    - git -C pandas apply ../foo.patch
     - build_wheel $REPO_DIR $PLAT
 
 script:

--- a/foo.patch
+++ b/foo.patch
@@ -1,8 +1,8 @@
 diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
-index 9fe8b0f95..9be107f9c 100644
+index 9fe8b0f95..4660da269 100644
 --- a/pandas/tests/test_downstream.py
 +++ b/pandas/tests/test_downstream.py
-@@ -135,8 +135,23 @@ def test_pyarrow(df):
+@@ -135,11 +135,27 @@ def test_pyarrow(df):
  
  def test_missing_required_dependency():
      # GH 23868
@@ -28,3 +28,8 @@ index 9fe8b0f95..9be107f9c 100644
  
      with pytest.raises(subprocess.CalledProcessError) as exc:
          subprocess.check_output(call, stderr=subprocess.STDOUT)
+ 
+     output = exc.value.stdout.decode()
+-    assert all(x in output for x in ['numpy', 'pytz', 'dateutil'])
++    for name in ['numpy', 'pytz', 'dateutil']:
++        assert name in output

--- a/foo.patch
+++ b/foo.patch
@@ -1,12 +1,17 @@
 diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
-index e76315299..9be107f9c 100644
+index 9fe8b0f95..9be107f9c 100644
 --- a/pandas/tests/test_downstream.py
 +++ b/pandas/tests/test_downstream.py
-@@ -139,7 +139,19 @@ def test_missing_required_dependency():
-     # -S : disable site-packages
-     # -s : disable user site-packages
-     # -E : disable PYTHON* env vars, especially PYTHONPATH
--    call = ['python', '-S', '-s', '-E', '-c', 'import pandas']
+@@ -135,8 +135,23 @@ def test_pyarrow(df):
+ 
+ def test_missing_required_dependency():
+     # GH 23868
+-    # use the -S flag to disable site-packages
+-    call = ['python', '-S', '-c', 'import pandas']
++    # To ensure proper isolation, we pass these flags
++    # -S : disable site-packages
++    # -s : disable user site-packages
++    # -E : disable PYTHON* env vars, especially PYTHONPATH
 +    # And, that's apparently not enough, so we give up.
 +    # https://github.com/MacPython/pandas-wheels/pull/50
 +    try:

--- a/foo.patch
+++ b/foo.patch
@@ -1,16 +1,15 @@
 diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
-index 9fe8b0f95..470108ae4 100644
+index 9fe8b0f95..9df1ee690 100644
 --- a/pandas/tests/test_downstream.py
 +++ b/pandas/tests/test_downstream.py
-@@ -135,8 +135,9 @@ def test_pyarrow(df):
- 
+@@ -136,7 +136,9 @@ def test_pyarrow(df):
  def test_missing_required_dependency():
      # GH 23868
--    # use the -S flag to disable site-packages
+     # use the -S flag to disable site-packages
 -    call = ['python', '-S', '-c', 'import pandas']
-+    # -s : disable user site-packages
-+    # -S : disable module site
-+    call = ['python', '-s' '-S', '-c', 'import pandas']
++    # This test fails if any of numpy, pytz, and dateutil are installed
++    # in the
++    call = ['python', '-S', '-s', '-E', '-c', 'import pandas']
  
      with pytest.raises(subprocess.CalledProcessError) as exc:
          subprocess.check_output(call, stderr=subprocess.STDOUT)

--- a/foo.patch
+++ b/foo.patch
@@ -1,0 +1,16 @@
+diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
+index 9fe8b0f95..470108ae4 100644
+--- a/pandas/tests/test_downstream.py
++++ b/pandas/tests/test_downstream.py
+@@ -135,8 +135,9 @@ def test_pyarrow(df):
+ 
+ def test_missing_required_dependency():
+     # GH 23868
+-    # use the -S flag to disable site-packages
+-    call = ['python', '-S', '-c', 'import pandas']
++    # -s : disable user site-packages
++    # -S : disable module site
++    call = ['python', '-s' '-S', '-c', 'import pandas']
+ 
+     with pytest.raises(subprocess.CalledProcessError) as exc:
+         subprocess.check_output(call, stderr=subprocess.STDOUT)

--- a/foo.patch
+++ b/foo.patch
@@ -1,22 +1,25 @@
 diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
-index 9fe8b0f95..f1ee5723d 100644
+index e76315299..9be107f9c 100644
 --- a/pandas/tests/test_downstream.py
 +++ b/pandas/tests/test_downstream.py
-@@ -135,11 +135,15 @@ def test_pyarrow(df):
- 
- def test_missing_required_dependency():
-     # GH 23868
--    # use the -S flag to disable site-packages
--    call = ['python', '-S', '-c', 'import pandas']
-+    # To ensure proper isolation, we pass these flags
-+    # -S : disable site-packages
-+    # -s : disable user site-packages
-+    # -E : disable PYTHON* env vars, especially PYTHONPATH
-+    call = ['python', '-S', '-s', '-E', '-c', 'import pandas']
+@@ -139,7 +139,19 @@ def test_missing_required_dependency():
+     # -S : disable site-packages
+     # -s : disable user site-packages
+     # -E : disable PYTHON* env vars, especially PYTHONPATH
+-    call = ['python', '-S', '-s', '-E', '-c', 'import pandas']
++    # And, that's apparently not enough, so we give up.
++    # https://github.com/MacPython/pandas-wheels/pull/50
++    try:
++        subprocess.check_output(['python', '-sSE', '-c', 'import numpy'],
++                                stderr=subprocess.DEVNULL)
++    except subprocess.CalledProcessError:
++        # NumPy is not around, we can do the test
++        pass
++    else:
++        # NumPy is in the isolation environment, give up.
++        pytest.skip("Required dependencies in isolated environment.")
++
++    call = ['python', '-sSE', '-c', 'import pandas']
  
      with pytest.raises(subprocess.CalledProcessError) as exc:
          subprocess.check_output(call, stderr=subprocess.STDOUT)
- 
-     output = exc.value.stdout.decode()
-+    assert output == b'123'
-     assert all(x in output for x in ['numpy', 'pytz', 'dateutil'])

--- a/foo.patch
+++ b/foo.patch
@@ -1,15 +1,22 @@
 diff --git a/pandas/tests/test_downstream.py b/pandas/tests/test_downstream.py
-index 9fe8b0f95..9df1ee690 100644
+index 9fe8b0f95..f1ee5723d 100644
 --- a/pandas/tests/test_downstream.py
 +++ b/pandas/tests/test_downstream.py
-@@ -136,7 +136,9 @@ def test_pyarrow(df):
+@@ -135,11 +135,15 @@ def test_pyarrow(df):
+ 
  def test_missing_required_dependency():
      # GH 23868
-     # use the -S flag to disable site-packages
+-    # use the -S flag to disable site-packages
 -    call = ['python', '-S', '-c', 'import pandas']
-+    # This test fails if any of numpy, pytz, and dateutil are installed
-+    # in the
++    # To ensure proper isolation, we pass these flags
++    # -S : disable site-packages
++    # -s : disable user site-packages
++    # -E : disable PYTHON* env vars, especially PYTHONPATH
 +    call = ['python', '-S', '-s', '-E', '-c', 'import pandas']
  
      with pytest.raises(subprocess.CalledProcessError) as exc:
          subprocess.check_output(call, stderr=subprocess.STDOUT)
+ 
+     output = exc.value.stdout.decode()
++    assert output == b'123'
+     assert all(x in output for x in ['numpy', 'pytz', 'dateutil'])


### PR DESCRIPTION
It seems like the build deps are present in the environment, even if we use `-sSE`. At this point, I think we skip the test, but checking if NumPy is in the isolation env before doing the test. That's what fde33a7bedf17f7ce24d22c098984446b979a723
 is testing.