### PR TITLE
Bump deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython==0.28.2"
       # binary-only for cryptogrpahy. See https://github.com/pandas-dev/pandas/issues/26589
       # Moto picks it up, and they don't distribute 32-bit wheels.
-    - TEST_DEPENDS="$NP_TEST_DEP pytest==4.3.1 pytest-xdist==1.26.1 pytest-mock moto hypothesis wheel==0.31.1 cryptography --only-binary=cryptography"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest>=4.0.2 pytest-xdist pytest-mock moto hypothesis>=3.58 wheel==0.31.1 cryptography --only-binary=cryptography"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install


### PR DESCRIPTION
Don't see an easy way to pass the `[test]` extras require right now.