### PR TITLE
re-add 32-bit Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
         - NP_BUILD_DEP="numpy==1.14.5"
         - NP_TEST_DEP="numpy==1.14.5"
     - os: linux
+       env:
+         - MB_PYTHON_VERSION=3.5
+         - PLAT=i686
+    - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - NP_BUILD_DEP="numpy==1.14.5"
         - NP_TEST_DEP="numpy==1.14.5"
     - os: linux
-       env:
+      env:
          - MB_PYTHON_VERSION=3.5
          - PLAT=i686
     - os: linux


### PR DESCRIPTION
This was added in https://github.com/MacPython/pandas-wheels/pull/35/files and accidentally removed.