### PR TITLE
Pin pytest to 5.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
     - CONTAINER="wheels";  # pre-relesae
     - BUILD_COMMIT=$BUILD_COMMIT;
     - BUILD_DEPENDS="$NP_BUILD_DEP $EXTRA_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP pytest>=4.0.2 pytest-xdist hypothesis"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest==5.3.5 pytest-xdist hypothesis"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install


### PR DESCRIPTION
pytest 5.4.0 was released between the PR build ran (https://travis-ci.org/github/MacPython/pandas-wheels/jobs/661583624) and the merge build :)

We have failures with 5.4.0

```
==================================== ERRORS ====================================

_ ERROR collecting venv/lib/python3.7/site-packages/pandas/tests/io/test_html.py _

In function "test_to_html_compat":

Parameter "flavor" should be declared explicitly via indirect or in function itself

_ ERROR collecting venv/lib/python3.7/site-packages/pandas/tests/io/excel/test_writers.py _

In function "test_excel_sheet_size":

Parameter "engine" should be declared explicitly via indirect or in function itself

_ ERROR collecting venv/lib/python3.7/site-packages/pandas/tests/resample/test_base.py _

In function "test_asfreq":

Parameter "_index_factory" should be declared explicitly via indirect or in function itself

_ ERROR collecting venv/lib/python3.7/site-packages/pandas/tests/resample/test_datetime_index.py _

In function "test_resample_basic":

Parameter "_index_start" should be declared explicitly via indirect or in function itself

_ ERROR collecting venv/lib/python3.7/site-packages/pandas/tests/util/test_util.py _

In function "test_datapath_missing":

Parameter "strict_data_files" should be declared explicitly via indirect or in function itself
```