### PR TITLE
BLD: Bump minimum version of Cython to 0.29.16

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -12,7 +12,7 @@ jobs:
       BUILD_COMMIT: "v1.0.3"
       PLAT: "x86_64"
       NP_BUILD_DEP: "numpy==1.13.3"
-      CYTHON_BUILD_DEP: "cython==0.29.13"
+      CYTHON_BUILD_DEP: "cython==0.29.16"
       NIGHTLY_BUILD_COMMIT: "master"
       NIGHTLY_BUILD: "false"
       TEST_DEPENDS: "pytest pytest-xdist hypothesis"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -10,7 +10,7 @@ jobs:
     variables:
       BUILD_COMMIT: "v1.0.3"
       NP_BUILD_DEP: "1.13.3"
-      CYTHON_BUILD_DEP: "0.29.13"
+      CYTHON_BUILD_DEP: "0.29.16"
       NIGHTLY_BUILD_COMMIT: "master"
       NIGHTLY_BUILD: "false"
       PYTHON_ARCH: "x64"


### PR DESCRIPTION
This is a follow-up of pandas-dev/pandas#33334