### PR TITLE
re-enable testing for py3.7 environments

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -31,6 +31,5 @@ function run_tests {
     pip list
     python -c 'import pandas; pandas.show_versions()'
     # Skip test_maybe_promote_int_with_int: https://github.com/pandas-dev/pandas/issues/31856
-    # TestPandasContainer for 3.7.0 failure
-    python -c 'import sys; import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_maybe_promote_int_with_int and not test_file_descriptor_leak"]) if sys.version_info[:2] != (3, 7) else None'
+    python -c 'import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_maybe_promote_int_with_int and not test_file_descriptor_leak"])'
 }


### PR DESCRIPTION
tested in https://github.com/MacPython/pandas-wheels/pull/111 and https://github.com/MacPython/pandas-wheels/pull/109

