### PR TITLE
unpin pytest-xdist and remove skip for test_file_descriptor_leak

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -15,7 +15,7 @@ jobs:
       CYTHON_BUILD_DEP: "cython==0.29.21"
       NIGHTLY_BUILD_COMMIT: "master"
       NIGHTLY_BUILD: "false"
-      TEST_DEPENDS: "pytest pytest-xdist==1.* hypothesis"
+      TEST_DEPENDS: "pytest pytest-xdist hypothesis"
       TEST_DIR: "tmp_for_test"
     strategy:
       matrix:

--- a/config.sh
+++ b/config.sh
@@ -32,5 +32,5 @@ function run_tests {
     python -c 'import pandas; pandas.show_versions()'
     # Skip test_maybe_promote_int_with_int: https://github.com/pandas-dev/pandas/issues/31856
     # TestPandasContainer for 3.7.0 failure
-    python -c 'import sys; import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_maybe_promote_int_with_int and not test_file_descriptor_leak"]) if sys.version_info[:2] != (3, 7) else None'
+    python -c 'import sys; import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_maybe_promote_int_with_int"]) if sys.version_info[:2] != (3, 7) else None'
 }


### PR DESCRIPTION
probably will be a merge conflict with https://github.com/MacPython/pandas-wheels/pull/115 but want to keep commits atomic.

closes https://github.com/MacPython/pandas-wheels/issues/95

can also remove skip for test_file_descriptor_leak https://github.com/pandas-dev/pandas/issues/35489#issuecomment-676554202

see also https://github.com/pandas-dev/pandas/pull/35910