### PR TITLE
Pin anaconda-client build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ after_success:
           source extra_functions.sh;
           for f in wheelhouse/*.whl; do rename_wheel $f; done;
           ANACONDA_ORG="scipy-wheels-nightly";
-          pip install git+https://github.com/Anaconda-Server/anaconda-client;
+          pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@ce89e4351eef;
           anaconda -t ${PANDAS_NIGHTLY_UPLOAD_TOKEN} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi
     # for merges (push events) we use the staging area instead;
@@ -85,6 +85,6 @@ after_success:
     # multibuild-wheels-staging
     - if [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
           ANACONDA_ORG="multibuild-wheels-staging";
-          pip install git+https://github.com/Anaconda-Server/anaconda-client;
+          pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@ce89e4351eef;
           anaconda -t ${PANDAS_STAGING_UPLOAD_TOKEN} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi


### PR DESCRIPTION
Pin the anaconda-client commit hash used for Travis pip installs to avoid a problematic dependency addition to requirements.txt.

See: https://github.com/MacPython/scipy-wheels/pull/116 for more details.