### PR TITLE
CI: Switch to Ubuntu Latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
   - template: azure/posix.yml
     parameters:
       name: linux
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
       matrix:
         py_3.7_32:
           MB_PYTHON_VERSION: "3.7"


### PR DESCRIPTION
closes #139
We use Ubuntu Latest when testing on GHA on the main repo. One of the jobs failed, but it looks flaky, so if someone could restart that, that would be nice.