### PR TITLE
CI: Bump Numpy for aarch Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ jobs:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP="numpy==1.17.3"
-        - NP_TEST_DEP="numpy==1.17.3"
+        - NP_BUILD_DEP="numpy==1.19.1"
+        - NP_TEST_DEP="numpy==1.19.1"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8


### PR DESCRIPTION
closes #121
The min version for numpy on aarch should be 1.19.1 I think(otherwise tests fail).
Was not caught in #141 because Travis CI doesn't run on PRs.