### PR TITLE
CI: Bump VM Image Versions in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   - template: azure/windows.yml
     parameters:
       name: windows
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
       matrix:
         py_3.7_32:
           PYTHON_VERSION: "3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   - template: azure/windows.yml
     parameters:
       name: windows
-      vmImage: windows-2019
+      vmImage: vs2017-win2016
       matrix:
         py_3.7_32:
           PYTHON_VERSION: "3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   - template: azure/windows.yml
     parameters:
       name: windows
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
       matrix:
         py_3.7_32:
           PYTHON_VERSION: "3.7"
@@ -91,7 +91,7 @@ jobs:
   - template: azure/posix.yml
     parameters:
       name: macOS
-      vmImage: macOS-10.14
+      vmImage: macOS-10.15
       matrix:
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,9 +68,8 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
-          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/"
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build
           python setup.py bdist_wheel
           ls dist

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,9 +68,8 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
-          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/x86/"
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC142.CRT/msvcp140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC142.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build
           python setup.py bdist_wheel
           ls dist

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,8 +68,8 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Redist/MSVC/14.16.27012/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Redist/MSVC/14.16.27012/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/16.10.31410/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/16.10.31410/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build
           python setup.py bdist_wheel
           ls dist

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,8 +68,8 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/16.10.31410/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/16.10.31410/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build
           python setup.py bdist_wheel
           ls dist

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,6 +68,7 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
+          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/x86/"
           cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
           cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30036/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,6 +68,7 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
+          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/"
           cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
           cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.24.28127/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
           python setup.py build


### PR DESCRIPTION
Mirroring some changes we made in the other repo.

~~Not bumping windows since we are redistributing some dlls from Visual Studio 2017, and it might be risky to upgrade Visual Studio.~~
See below
