### PR TITLE
Xfail more tests for python 3.10

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -9,7 +9,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       REPO_DIR: "pandas"
-      BUILD_COMMIT: "master"
+      BUILD_COMMIT: "v1.3.2"
       PLAT: "x86_64"
       NP_BUILD_DEP: "numpy==1.17.3"
       CYTHON_BUILD_DEP: "cython==0.29.21"

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -9,7 +9,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       REPO_DIR: "pandas"
-      BUILD_COMMIT: "v1.3.2"
+      BUILD_COMMIT: "master"
       PLAT: "x86_64"
       NP_BUILD_DEP: "numpy==1.17.3"
       CYTHON_BUILD_DEP: "cython==0.29.21"

--- a/config.sh
+++ b/config.sh
@@ -36,7 +36,7 @@ function run_tests {
     # Skip test_pairwise_with_self/test_no_pairwise_with_self: https://github.com/pandas-dev/pandas/issues/39553
     # Skip reduction tests and window test corr_sanity due to numpy issues: https://github.com/pandas-dev/pandas/issues/41935
     if [[ "$MB_PYTHON_VERSION" == "3.10" ]]; then
-        python -c 'import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_rolling_var_numerical_issues and not test_rolling_skew_kurt_large_value_range and not test_float_precision_options and not test_pairwise_with_self and not test_no_pairwise_with_self and not test_corr_sanity and not TestReductions and not TestIndexReductions"])'
+        python -c 'import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_rolling_var_numerical_issues and not test_rolling_skew_kurt_large_value_range and not test_float_precision_options and not test_pairwise_with_self and not test_no_pairwise_with_self and not test_corr_sanity and not TestReductions and not TestIndexReductions and not test_searchsorted and not test_replace_with_compiled_regex"])'
     else
         python -c 'import pandas; pandas.test(extra_args=["-m not clipboard", "--skip-slow", "--skip-network", "--skip-db", "-n=2", "-k not test_rolling_var_numerical_issues and not test_rolling_skew_kurt_large_value_range and not test_float_precision_options and not test_pairwise_with_self and not test_no_pairwise_with_self"])'
     fi


### PR DESCRIPTION
Sadly, more tests need xfailing on master. (Not 1.3.2 though)

This was not caught by bad luck. 

In the initial PR, https://dev.azure.com/pandas-dev/pandas-wheels/_build/results?buildId=64931&view=logs&jobId=d1321064-f6c3-56b7-0172-6d994d01c836 was the build that I used to check that I was xfailing correctly for master. For some reason, that one passed, but the nightly builds are failing.

cc @simonjayhawkins 