### PR TITLE
Automatically check for missing DLLs on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,16 @@ trigger:
 pr:
 - master
 
+resources:
+  containers:
+  - container: windows-container
+    image: mcr.microsoft.com/windows/servercore:ltsc2019
+
 jobs:
   - template: azure/windows.yml
     parameters:
       name: windows
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
       matrix:
         py_3.7_32:
           PYTHON_VERSION: "3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,6 @@ trigger:
 pr:
 - master
 
-resources:
-  containers:
-  - container: windows-container
-    image: mcr.microsoft.com/windows/servercore:ltsc2019
-
 jobs:
   - template: azure/windows.yml
     parameters:

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -96,7 +96,7 @@ jobs:
           docker run -v %cd%:c:\pandas python:$(PYTHON_VERSION)-windowsservercore /pandas/check_windows_dlls.bat
         displayName: Ensure wheel imports correctly
         # No Windows images for x86
-        condition: eq(variables['PYTHON_ARCH'], 'x64')
+        condition: and(eq(variables['SKIP_BUILD'], 'false'), eq(variables['PYTHON_ARCH'], 'x64'))
 
       - bash: echo "##vso[task.prependpath]$CONDA/Scripts"
         displayName: Add conda to PATH

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -80,17 +80,17 @@ jobs:
           popd
         displayName: Build wheel
         condition: eq(variables['SKIP_BUILD'], 'false')
-       - bash: |
-           set -e
-           source extra_functions.sh
-           source config.sh
-           setup_test_venv
-           pip install pandas/dist/pandas-*.whl
-           run_tests
-           teardown_test_venv
-         displayName: Install wheel and test
-         condition: eq(variables['SKIP_BUILD'], 'false')
-      
+      - bash: |
+          set -e
+          source extra_functions.sh
+          source config.sh
+          setup_test_venv
+          pip install pandas/dist/pandas-*.whl
+          run_tests
+          teardown_test_venv
+        displayName: Install wheel and test
+        condition: eq(variables['SKIP_BUILD'], 'false')
+
       - script: |
           docker pull python:$(PYTHON_VERSION)-windowsservercore
           docker run -v %cd%:c:\pandas python:$(PYTHON_VERSION)-windowsservercore /pandas/check_windows_dlls.bat

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -68,8 +68,11 @@ jobs:
           pip install --timeout=60 $TEST_DEPENDS Cython==$CYTHON_BUILD_DEP
           pip install twine wheel
           pushd pandas
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Redist/MSVC/14.16.27012/$PYTHON_ARCH/Microsoft.VC141.CRT/msvcp140.dll" pandas/_libs/window
-          cp "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Redist/MSVC/14.16.27012/$PYTHON_ARCH/Microsoft.VC141.CRT/concrt140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/$PYTHON_ARCH/Microsoft.VC142.CRT/msvcp140.dll" pandas/_libs/window
+          cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/$PYTHON_ARCH/Microsoft.VC142.CRT/concrt140.dll" pandas/_libs/window
+          if [ "$PYTHON_ARCH" == "x64" ]; then
+            cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/x64/Microsoft.VC142.CRT/vcruntime140_1.dll" pandas/_libs/window
+          fi
           python setup.py build
           python setup.py bdist_wheel
           ls dist
@@ -77,16 +80,23 @@ jobs:
           popd
         displayName: Build wheel
         condition: eq(variables['SKIP_BUILD'], 'false')
-      - bash: |
-          set -e
-          source extra_functions.sh
-          source config.sh
-          setup_test_venv
-          pip install pandas/dist/pandas-*.whl
-          run_tests
-          teardown_test_venv
-        displayName: Install wheel and test
-        condition: eq(variables['SKIP_BUILD'], 'false')
+       - bash: |
+           set -e
+           source extra_functions.sh
+           source config.sh
+           setup_test_venv
+           pip install pandas/dist/pandas-*.whl
+           run_tests
+           teardown_test_venv
+         displayName: Install wheel and test
+         condition: eq(variables['SKIP_BUILD'], 'false')
+      
+      - script: |
+          docker pull python:$(PYTHON_VERSION)-windowsservercore
+          docker run -v %cd%:c:\pandas python:$(PYTHON_VERSION)-windowsservercore /pandas/check_windows_dlls.bat
+        displayName: Ensure wheel imports correctly
+        # No Windows images for x86
+        condition: eq(variables['PYTHON_ARCH'], 'x64')
 
       - bash: echo "##vso[task.prependpath]$CONDA/Scripts"
         displayName: Add conda to PATH

--- a/check_windows_dlls.bat
+++ b/check_windows_dlls.bat
@@ -1,0 +1,4 @@
+python --version
+pip install pytz six numpy python-dateutil
+pip install --find-links=pandas/pandas/dist --no-index pandas
+python -c "import pandas as pd; print(pd.__version__)"


### PR DESCRIPTION
closes #150

Merge for 1.4, since a rc would catch any problems here. This is a blocker since the Windows 2016 image is going away next year.

DLLS aren't checked on 32 bit since I cannot find a 32-bit python image on windows.

cc @simonjayhawkins 