### PR TITLE
BLD: No more 32-bit Linux wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,35 +62,16 @@ jobs:
       name: linux
       vmImage: ubuntu-latest
       matrix:
-        py_3.7_32:
-          MB_PYTHON_VERSION: "3.7"
-          MB_ML_VER: "2014"
-          PLAT: "i686"
-          NP_BUILD_DEP: "numpy==1.17.3"
-          # pandas 1.4 requires py3.8+, remove this job on 1.4 release
-          NIGHTLY_BUILD: "false"
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"
           MB_ML_VER: "2014"
           NP_BUILD_DEP: "numpy==1.17.3"
           # pandas 1.4 requires py3.8+, remove this job on 1.4 release
           NIGHTLY_BUILD: "false"
-        py_3.8_32:
-          MB_PYTHON_VERSION: "3.8"
-          MB_ML_VER: "2014"
-          PLAT: "i686"
-          NP_BUILD_DEP: "numpy==1.17.3"
-          NIGHTLY_BUILD: "true"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
           MB_ML_VER: "2014"
           NP_BUILD_DEP: "numpy==1.17.3"
-          NIGHTLY_BUILD: "true"
-        py_3.9_32:
-          MB_PYTHON_VERSION: "3.9"
-          MB_ML_VER: "2014"
-          PLAT: "i686"
-          NP_BUILD_DEP: "numpy==1.19.3"
           NIGHTLY_BUILD: "true"
         py_3.9_64:
           MB_PYTHON_VERSION: "3.9"


### PR DESCRIPTION
Tentatively merge for 1.4(or whatever release comes after numpy 1.22, where they drop 32-bit wheel Linux support)

Failures are because of the fixes to tests for Python 3.9.7 not being present on 1.3.4(but are there for 1.3.5).