### PR TITLE
Revert "tzdata is a required dependency when testing on Windows"

### DIFF
--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -14,8 +14,7 @@ jobs:
       NIGHTLY_BUILD_COMMIT: "main"
       NIGHTLY_BUILD: "false"
       PYTHON_ARCH: "x64"
-      # https://github.com/pandas-dev/pandas/issues/47332
-      TEST_DEPENDS: "pytest pytest-xdist hypothesis tzdata"
+      TEST_DEPENDS: "pytest pytest-xdist hypothesis"
       TEST_DIR: '$(Agent.WorkFolder)/tmp_for_test'
     strategy:
       matrix:


### PR DESCRIPTION
Reverts MacPython/pandas-wheels#185
Depends on pandas-dev/pandas#47467