### PR TITLE
Remove setuptools pin

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -36,8 +36,6 @@ function run_tests {
     echo $PATH
     echo ${MB_PYTHON_VERSION}
     which -a python
-    # Pin setuptools < 60
-    pip install "setuptools<60"
     pip list
     python -c 'import pandas; pandas.show_versions()'
     # Skip test_float_precision_options: https://github.com/pandas-dev/pandas/issues/36429


### PR DESCRIPTION
We pinned setuptools in the main repository in december last year, because 60 was causing our ci to fail. The pin was removed in the meantime, hence removing it here too.

https://github.com/pandas-dev/pandas/pull/44989/